### PR TITLE
feat: Ollama GPU 즉시 해제 (keep_alive: 0)

### DIFF
--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -82,6 +82,7 @@ export async function translateWithOllama(
       system: systemPrompt,
       prompt: text,
       stream: false,
+      keep_alive: 0,
     }),
     signal: onAbort,
   });


### PR DESCRIPTION
## 요약
- Ollama API 호출 시 `keep_alive: 0` 추가하여 응답 직후 GPU 메모리 해제

## 관련 이슈
Closed #15

## 체크리스트
- [x] 빌드 성공
- [x] 번역 테스트 6개 통과