### PR TITLE
feat: .md 파일 연결 및 CLI 인자로 파일 열기

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,9 +2,10 @@ mod commands;
 
 use commands::WatcherState;
 use std::sync::Mutex;
+use tauri::Emitter;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(initial_file: Option<String>) {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
@@ -15,6 +16,16 @@ pub fn run() {
             commands::write_file,
             commands::watch_directory,
         ])
+        .setup(move |app| {
+            if let Some(path) = initial_file {
+                let handle = app.handle().clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    let _ = handle.emit("open-file", path);
+                });
+            }
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    mdeditor_lib::run()
+    let file_path = std::env::args().nth(1);
+    mdeditor_lib::run(file_path);
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,6 +9,15 @@
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },
+  "bundle": {
+    "fileAssociations": [
+      {
+        "ext": ["md", "markdown", "mdown", "mkd", "txt"],
+        "mimeType": "text/markdown",
+        "description": "Markdown Document"
+      }
+    ]
+  },
   "app": {
     "windows": [
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import { AppLayout } from "./components/layout/AppLayout";
 import { FileTree } from "./components/sidebar/FileTree";
 import { MarkdownEditor } from "./components/editor/MarkdownEditor";
 import { MarkdownPreview } from "./components/preview/MarkdownPreview";
 import { useFileSystem } from "./hooks/useFileSystem";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useEditorStore } from "./stores/editorStore";
 import "./App.css";
 
 function App() {
@@ -29,6 +32,23 @@ function App() {
     onOpenFolder: openFolder,
     onTranslate: handleTranslate,
   });
+
+  useEffect(() => {
+    const unlisten = listen<string>("open-file", async (event) => {
+      const filePath = event.payload;
+      if (filePath) {
+        try {
+          const fileContent = await invoke<string>("read_file", { path: filePath });
+          useEditorStore.getState().setActiveFile(filePath, fileContent);
+        } catch (err) {
+          console.error("파일 열기 실패:", err);
+        }
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
 
   return (
     <AppLayout


### PR DESCRIPTION
## 요약
- CLI 인자로 전달된 .md 파일을 앱 시작 시 자동 열기
- tauri.conf.json에 파일 연결 설정 (.md, .markdown, .txt 등)
- 멀티 인스턴스 지원

## 관련 이슈
Closed #16

## 체크리스트
- [x] 빌드 성공
- [x] CLI 인자 처리 (main.rs → lib.rs → 프론트엔드 이벤트)
- [x] 파일 연결 설정