### PR TITLE
feat: AppImage 빌드 설정

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "MDeditor",
   "version": "0.1.0",
-  "identifier": "com.mdeditor.app",
+  "identifier": "com.mdeditor.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
@@ -10,6 +10,12 @@
     "frontendDist": "../dist"
   },
   "bundle": {
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.png"
+    ],
     "fileAssociations": [
       {
         "ext": ["md", "markdown", "mdown", "mkd", "txt"],


### PR DESCRIPTION
## 요약
- bundle.icon 설정 추가로 AppImage 빌드 성공
- 식별자 com.mdeditor.desktop으로 변경

## 관련 이슈
Closed #17

## 검증
- AppImage 빌드 성공: `MDeditor_0.1.0_amd64.AppImage` (81MB)

## 체크리스트
- [x] AppImage 생성 확인
- [x] 프로덕션 빌드 성공