### PR TITLE
feat: Linux 설치/제거 스크립트

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,22 @@
 - 영어/중국어 → 한국어 번역 (Ollama + gemma3:4b)
 - 한국어/영어 UI
 
-## 실행
+## 설치 (Linux)
+
+[Releases](https://github.com/soyuncho16/MDeditor/releases)에서 `MDeditor_x.x.x_amd64.AppImage`와 `install.sh`를 같은 폴더에 다운로드한 후:
+
+```bash
+bash install.sh
+```
+
+설치 후 앱 런처에서 "MDeditor"를 검색하거나, `.md` 파일을 더블클릭하여 열 수 있습니다.
+
+제거:
+```bash
+bash uninstall.sh
+```
+
+## 개발 모드
 
 ```bash
 # 의존성 설치
@@ -18,8 +33,6 @@ npm install
 # 개발 모드 (핫 리로드, 코드 수정 시 자동 반영)
 npm run tauri dev
 ```
-
-개발 모드로 실행하면 MDeditor 데스크톱 창이 열립니다.
 
 ## 개발
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -e
+
+APP_NAME="MDeditor"
+APPIMAGE_NAME="MDeditor_0.1.0_amd64.AppImage"
+INSTALL_DIR="$HOME/.local/bin"
+ICON_DIR="$HOME/.local/share/icons"
+DESKTOP_DIR="$HOME/.local/share/applications"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPIMAGE_PATH="$SCRIPT_DIR/$APPIMAGE_NAME"
+
+# AppImage 파일 확인
+if [ ! -f "$APPIMAGE_PATH" ]; then
+    # 같은 디렉토리에 없으면 현재 디렉토리에서 찾기
+    APPIMAGE_PATH="$(pwd)/$APPIMAGE_NAME"
+    if [ ! -f "$APPIMAGE_PATH" ]; then
+        echo "오류: $APPIMAGE_NAME 파일을 찾을 수 없습니다."
+        echo "이 스크립트를 AppImage 파일과 같은 폴더에서 실행하세요."
+        exit 1
+    fi
+fi
+
+echo "MDeditor 설치 중..."
+
+# 디렉토리 생성
+mkdir -p "$INSTALL_DIR" "$ICON_DIR" "$DESKTOP_DIR"
+
+# AppImage 복사 및 실행 권한
+cp "$APPIMAGE_PATH" "$INSTALL_DIR/$APP_NAME"
+chmod +x "$INSTALL_DIR/$APP_NAME"
+
+# 아이콘 추출 (AppImage 내부에서)
+# 임시 디렉토리에 AppImage 마운트하여 아이콘 추출
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+"$INSTALL_DIR/$APP_NAME" --appimage-extract usr/share/icons/hicolor/128x128/apps/*.png > /dev/null 2>&1 || true
+
+EXTRACTED_ICON=$(find "$TEMP_DIR/squashfs-root" -name "*.png" -path "*/128x128/*" 2>/dev/null | head -1)
+if [ -n "$EXTRACTED_ICON" ]; then
+    cp "$EXTRACTED_ICON" "$ICON_DIR/mdeditor.png"
+else
+    # 추출 실패 시 기본 아이콘 생성 (1x1 투명 PNG)
+    echo "경고: 아이콘을 추출하지 못했습니다. 기본 아이콘을 사용합니다."
+    python3 -c "
+from PIL import Image
+img = Image.new('RGBA', (128, 128), (100, 149, 237, 255))
+img.save('$ICON_DIR/mdeditor.png')
+" 2>/dev/null || true
+fi
+rm -rf "$TEMP_DIR"
+
+# .desktop 파일 생성
+cat > "$DESKTOP_DIR/mdeditor.desktop" << DESKTOP
+[Desktop Entry]
+Name=MDeditor
+Comment=로컬 마크다운 에디터
+Exec=$INSTALL_DIR/$APP_NAME %f
+Icon=$ICON_DIR/mdeditor.png
+Terminal=false
+Type=Application
+Categories=TextEditor;Development;
+MimeType=text/markdown;text/plain;text/x-markdown;
+DESKTOP
+
+chmod +x "$DESKTOP_DIR/mdeditor.desktop"
+
+# 데스크톱 데이터베이스 갱신
+update-desktop-database "$DESKTOP_DIR" 2>/dev/null || true
+
+# MIME 타입 기본 앱 설정
+xdg-mime default mdeditor.desktop text/markdown 2>/dev/null || true
+
+echo ""
+echo "✓ MDeditor 설치 완료!"
+echo "  - 실행: 앱 런처에서 'MDeditor' 검색"
+echo "  - .md 파일 더블클릭으로 열기 가능"
+echo ""
+echo "제거하려면: bash $(dirname "$0")/uninstall.sh"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "MDeditor 제거 중..."
+
+rm -f "$HOME/.local/bin/MDeditor"
+rm -f "$HOME/.local/share/icons/mdeditor.png"
+rm -f "$HOME/.local/share/applications/mdeditor.desktop"
+update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+
+echo "✓ MDeditor 제거 완료."


### PR DESCRIPTION
## 요약
- `scripts/install.sh`: AppImage 시스템 설치 + 앱 런처 등록 + .md 기본 앱 설정
- `scripts/uninstall.sh`: 깔끔한 제거
- README에 설치 방법 추가

## 사용법
AppImage와 install.sh를 같은 폴더에 놓고 `bash install.sh` 실행

## 체크리스트
- [x] 앱 런처에 아이콘 등록
- [x] .md 파일 기본 앱 설정
- [x] 제거 스크립트
- [x] README 업데이트