### PR TITLE
fix: AppImage FUSE 미설치 환경 실행 불가 수정

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,7 +55,7 @@ cat > "$DESKTOP_DIR/mdeditor.desktop" << DESKTOP
 [Desktop Entry]
 Name=MDeditor
 Comment=로컬 마크다운 에디터
-Exec=$INSTALL_DIR/$APP_NAME %f
+Exec=$INSTALL_DIR/$APP_NAME --appimage-extract-and-run %f
 Icon=$ICON_DIR/mdeditor.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
## 요약
- AppImage 실행 시 FUSE 의존성 문제로 앱 런처에서 열리지 않는 버그 수정
- `--appimage-extract-and-run` 플래그로 FUSE 없이도 실행 가능

## 원인
AppImage는 FUSE(libfuse2)가 필요하지만, Ubuntu 22.04+ 등 최신 배포판에는 기본 설치되지 않음. 앱 런처에서 실행 시 조용히 실패.

## 체크리스트
- [x] install.sh Exec 라인 수정