### PR TITLE
fix: 에디터/프리뷰 패널 크기 조절 기능 구현

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -19,8 +19,14 @@ export function AppLayout({
   cursorLine = 1,
   cursorCol = 1,
 }: AppLayoutProps) {
-  const { sidebarVisible, sidebarWidth, previewVisible, setSidebarWidth } =
-    useEditorStore();
+  const {
+    sidebarVisible,
+    sidebarWidth,
+    previewVisible,
+    editorPaneRatio,
+    setSidebarWidth,
+    setEditorPaneRatio,
+  } = useEditorStore();
   const containerRef = useRef<HTMLDivElement>(null);
   const isDraggingRef = useRef(false);
 
@@ -52,6 +58,33 @@ export function AppLayout({
     [setSidebarWidth],
   );
 
+  const handleEditorDrag = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isDraggingRef.current = true;
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        if (!isDraggingRef.current || !containerRef.current) return;
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const sidebarOffset = sidebarVisible ? sidebarWidth + 4 : 0;
+        const availableWidth = containerRect.width - sidebarOffset;
+        const mouseOffset = moveEvent.clientX - containerRect.left - sidebarOffset;
+        const ratio = Math.max(0.2, Math.min(0.8, mouseOffset / availableWidth));
+        setEditorPaneRatio(ratio);
+      };
+
+      const onMouseUp = () => {
+        isDraggingRef.current = false;
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+      };
+
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [sidebarVisible, sidebarWidth, setEditorPaneRatio],
+  );
+
   return (
     <div className={styles.container}>
       <TitleBar />
@@ -67,10 +100,18 @@ export function AppLayout({
             />
           </>
         )}
-        <div className={styles.editorPane}>{editor}</div>
+        <div
+          className={styles.editorPane}
+          style={previewVisible ? { flex: `0 0 ${editorPaneRatio * 100}%` } : undefined}
+        >
+          {editor}
+        </div>
         {previewVisible && (
           <>
-            <div className={styles.resizer} />
+            <div
+              className={styles.resizer}
+              onMouseDown={handleEditorDrag}
+            />
             <div className={styles.previewPane}>{preview}</div>
           </>
         )}

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -10,6 +10,7 @@ interface EditorState {
   sidebarVisible: boolean;
   sidebarWidth: number;
   previewVisible: boolean;
+  editorPaneRatio: number;
   isTranslating: boolean;
 
   setRootPath: (path: string, tree: FileEntry[]) => void;
@@ -20,6 +21,7 @@ interface EditorState {
   toggleSidebar: () => void;
   togglePreview: () => void;
   setSidebarWidth: (width: number) => void;
+  setEditorPaneRatio: (ratio: number) => void;
   setIsTranslating: (value: boolean) => void;
 }
 
@@ -32,6 +34,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
   sidebarVisible: true,
   sidebarWidth: 250,
   previewVisible: true,
+  editorPaneRatio: 0.5,
   isTranslating: false,
 
   setRootPath: (path, tree) => set({ rootPath: path, fileTree: tree }),
@@ -43,5 +46,6 @@ export const useEditorStore = create<EditorState>()((set) => ({
   toggleSidebar: () => set((s) => ({ sidebarVisible: !s.sidebarVisible })),
   togglePreview: () => set((s) => ({ previewVisible: !s.previewVisible })),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
+  setEditorPaneRatio: (ratio) => set({ editorPaneRatio: ratio }),
   setIsTranslating: (value) => set({ isTranslating: value }),
 }));


### PR DESCRIPTION
## Summary
- 프리뷰 리사이저에 누락된 드래그 핸들러(`handleEditorDrag`) 추가
- 스토어에 `editorPaneRatio` 상태 추가하여 에디터/프리뷰 비율 제어
- 비율 20%~80% 범위 제한으로 최소 너비 보장

## Test plan
- [ ] 에디터/프리뷰 경계를 드래그하여 좌우 비율 조절 확인
- [ ] 사이드바 열림/닫힘 상태에서 모두 정상 동작 확인
- [ ] 프리뷰 닫힌 상태에서 에디터가 전체 너비 차지 확인
- [ ] 기존 사이드바 리사이저 정상 동작 확인

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)