### PR TITLE
feat: 에디터/프리뷰 양방향 스크롤 동기화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { useState, useCallback, useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
+import type { EditorView } from "@codemirror/view";
 import { AppLayout } from "./components/layout/AppLayout";
 import { FileTree } from "./components/sidebar/FileTree";
 import { MarkdownEditor } from "./components/editor/MarkdownEditor";
 import { MarkdownPreview } from "./components/preview/MarkdownPreview";
 import { useFileSystem } from "./hooks/useFileSystem";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useScrollSync } from "./hooks/useScrollSync";
 import { useEditorStore } from "./stores/editorStore";
 import "./App.css";
 
@@ -14,6 +16,10 @@ function App() {
   const { openFolder, openFile, saveFile, loadChildren } = useFileSystem();
   const [cursorLine, setCursorLine] = useState(1);
   const [cursorCol, setCursorCol] = useState(1);
+  const [editorView, setEditorView] = useState<EditorView | null>(null);
+  const [previewPane, setPreviewPane] = useState<HTMLDivElement | null>(null);
+
+  useScrollSync({ editorView, previewEl: previewPane });
 
   const handleCursorChange = useCallback((line: number, col: number) => {
     setCursorLine(line);
@@ -59,8 +65,9 @@ function App() {
           onLoadChildren={loadChildren}
         />
       }
-      editor={<MarkdownEditor onCursorChange={handleCursorChange} />}
+      editor={<MarkdownEditor onCursorChange={handleCursorChange} onEditorView={setEditorView} />}
       preview={<MarkdownPreview />}
+      onPreviewPane={setPreviewPane}
       cursorLine={cursorLine}
       cursorCol={cursorCol}
     />

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -11,9 +11,10 @@ import styles from "./MarkdownEditor.module.css";
 
 interface MarkdownEditorProps {
   onCursorChange?: (line: number, col: number) => void;
+  onEditorView?: (view: EditorView | null) => void;
 }
 
-export function MarkdownEditor({ onCursorChange }: MarkdownEditorProps) {
+export function MarkdownEditor({ onCursorChange, onEditorView }: MarkdownEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const { content, activeFilePath, setContent } = useEditorStore();
@@ -22,6 +23,9 @@ export function MarkdownEditor({ onCursorChange }: MarkdownEditorProps) {
 
   const onCursorChangeRef = useRef(onCursorChange);
   onCursorChangeRef.current = onCursorChange;
+
+  const onEditorViewRef = useRef(onEditorView);
+  onEditorViewRef.current = onEditorView;
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -58,8 +62,10 @@ export function MarkdownEditor({ onCursorChange }: MarkdownEditorProps) {
     });
 
     viewRef.current = view;
+    onEditorViewRef.current?.(view);
 
     return () => {
+      onEditorViewRef.current?.(null);
       view.destroy();
     };
   }, [activeFilePath]); // activeFilePath 변경 시 에디터 재생성

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -10,6 +10,7 @@ interface AppLayoutProps {
   preview: React.ReactNode;
   cursorLine?: number;
   cursorCol?: number;
+  onPreviewPane?: (el: HTMLDivElement | null) => void;
 }
 
 export function AppLayout({
@@ -18,6 +19,7 @@ export function AppLayout({
   preview,
   cursorLine = 1,
   cursorCol = 1,
+  onPreviewPane,
 }: AppLayoutProps) {
   const {
     sidebarVisible,
@@ -112,7 +114,7 @@ export function AppLayout({
               className={styles.resizer}
               onMouseDown={handleEditorDrag}
             />
-            <div className={styles.previewPane}>{preview}</div>
+            <div className={styles.previewPane} ref={onPreviewPane}>{preview}</div>
           </>
         )}
       </div>

--- a/src/hooks/useScrollSync.ts
+++ b/src/hooks/useScrollSync.ts
@@ -1,0 +1,197 @@
+import { useEffect, useRef, useCallback } from "react";
+import type { EditorView } from "@codemirror/view";
+
+interface ScrollSyncOptions {
+  editorView: EditorView | null;
+  previewEl: HTMLElement | null;
+}
+
+export function useScrollSync({ editorView, previewEl }: ScrollSyncOptions) {
+  const scrollSourceRef = useRef<"editor" | "preview" | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const clearScrollSource = useCallback(() => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      scrollSourceRef.current = null;
+    }, 80);
+  }, []);
+
+  useEffect(() => {
+    if (!editorView || !previewEl) return;
+
+    const editorScroller = editorView.scrollDOM;
+
+    function findPreviewElementForLine(line: number): HTMLElement | null {
+      const elements = previewEl!.querySelectorAll<HTMLElement>("[data-source-line]");
+      let best: HTMLElement | null = null;
+      let bestLine = -1;
+
+      for (const el of elements) {
+        const elLine = parseInt(el.dataset.sourceLine ?? "", 10);
+        if (isNaN(elLine)) continue;
+        if (elLine <= line && elLine > bestLine) {
+          bestLine = elLine;
+          best = el;
+        }
+      }
+      return best;
+    }
+
+    function findNextPreviewElement(line: number): { el: HTMLElement; line: number } | null {
+      const elements = previewEl!.querySelectorAll<HTMLElement>("[data-source-line]");
+      let best: HTMLElement | null = null;
+      let bestLine = Infinity;
+
+      for (const el of elements) {
+        const elLine = parseInt(el.dataset.sourceLine ?? "", 10);
+        if (isNaN(elLine)) continue;
+        if (elLine > line && elLine < bestLine) {
+          bestLine = elLine;
+          best = el;
+        }
+      }
+      return best ? { el: best, line: bestLine } : null;
+    }
+
+    function handleEditorScroll() {
+      if (scrollSourceRef.current === "preview") return;
+      scrollSourceRef.current = "editor";
+
+      const scrollTop = editorScroller.scrollTop;
+      const scrollHeight = editorScroller.scrollHeight - editorScroller.clientHeight;
+
+      if (scrollHeight <= 0) return;
+
+      // Edge: top
+      if (scrollTop <= 0) {
+        previewEl!.scrollTop = 0;
+        clearScrollSource();
+        return;
+      }
+
+      // Edge: bottom
+      if (scrollTop >= scrollHeight - 1) {
+        previewEl!.scrollTop = previewEl!.scrollHeight - previewEl!.clientHeight;
+        clearScrollSource();
+        return;
+      }
+
+      // Find the top visible line in editor
+      const topPos = editorView!.posAtCoords({ x: 0, y: editorView!.documentTop })
+        ?? editorView!.viewport.from;
+      const topLine = editorView!.state.doc.lineAt(topPos).number;
+
+      const currentEl = findPreviewElementForLine(topLine);
+      const nextInfo = findNextPreviewElement(topLine);
+
+      if (!currentEl) {
+        // Fallback: ratio-based sync
+        const ratio = scrollTop / scrollHeight;
+        previewEl!.scrollTop = ratio * (previewEl!.scrollHeight - previewEl!.clientHeight);
+        clearScrollSource();
+        return;
+      }
+
+      const currentElTop = currentEl.offsetTop - previewEl!.offsetTop;
+
+      if (nextInfo) {
+        const currentLine = parseInt(currentEl.dataset.sourceLine ?? "1", 10);
+        const nextElTop = nextInfo.el.offsetTop - previewEl!.offsetTop;
+        const lineFraction = (topLine - currentLine) / (nextInfo.line - currentLine);
+        const targetTop = currentElTop + (nextElTop - currentElTop) * Math.max(0, Math.min(1, lineFraction));
+        previewEl!.scrollTop = targetTop;
+      } else {
+        previewEl!.scrollTop = currentElTop;
+      }
+
+      clearScrollSource();
+    }
+
+    function handlePreviewScroll() {
+      if (scrollSourceRef.current === "editor") return;
+      scrollSourceRef.current = "preview";
+
+      const scrollTop = previewEl!.scrollTop;
+      const scrollHeight = previewEl!.scrollHeight - previewEl!.clientHeight;
+
+      if (scrollHeight <= 0) return;
+
+      // Edge: top
+      if (scrollTop <= 0) {
+        editorScroller.scrollTop = 0;
+        clearScrollSource();
+        return;
+      }
+
+      // Edge: bottom
+      if (scrollTop >= scrollHeight - 1) {
+        editorScroller.scrollTop = editorScroller.scrollHeight - editorScroller.clientHeight;
+        clearScrollSource();
+        return;
+      }
+
+      // Find the element at the top of the preview viewport
+      const elements = previewEl!.querySelectorAll<HTMLElement>("[data-source-line]");
+      let currentEl: HTMLElement | null = null;
+      let nextEl: HTMLElement | null = null;
+
+      for (let i = 0; i < elements.length; i++) {
+        const elTop = elements[i].offsetTop - previewEl!.offsetTop;
+        if (elTop <= scrollTop + 5) {
+          currentEl = elements[i];
+          nextEl = elements[i + 1] ?? null;
+        } else {
+          if (!currentEl) {
+            currentEl = elements[i];
+            nextEl = elements[i + 1] ?? null;
+          }
+          break;
+        }
+      }
+
+      if (!currentEl) {
+        // Fallback: ratio-based sync
+        const ratio = scrollTop / scrollHeight;
+        editorScroller.scrollTop = ratio * (editorScroller.scrollHeight - editorScroller.clientHeight);
+        clearScrollSource();
+        return;
+      }
+
+      const currentLine = parseInt(currentEl.dataset.sourceLine ?? "1", 10);
+
+      let targetLine = currentLine;
+      if (nextEl) {
+        const nextLine = parseInt(nextEl.dataset.sourceLine ?? "1", 10);
+        const currentElTop = currentEl.offsetTop - previewEl!.offsetTop;
+        const nextElTop = nextEl.offsetTop - previewEl!.offsetTop;
+        const elRange = nextElTop - currentElTop;
+        if (elRange > 0) {
+          const fraction = (scrollTop - currentElTop) / elRange;
+          targetLine = currentLine + (nextLine - currentLine) * Math.max(0, Math.min(1, fraction));
+        }
+      }
+
+      // Scroll editor to the target line
+      const lineInfo = editorView!.state.doc.line(
+        Math.max(1, Math.min(Math.round(targetLine), editorView!.state.doc.lines)),
+      );
+      const coords = editorView!.coordsAtPos(lineInfo.from);
+      if (coords) {
+        const editorTop = editorView!.documentTop;
+        editorScroller.scrollTop = coords.top - editorTop;
+      }
+
+      clearScrollSource();
+    }
+
+    editorScroller.addEventListener("scroll", handleEditorScroll);
+    previewEl.addEventListener("scroll", handlePreviewScroll);
+
+    return () => {
+      editorScroller.removeEventListener("scroll", handleEditorScroll);
+      previewEl!.removeEventListener("scroll", handlePreviewScroll);
+      clearTimeout(timerRef.current);
+    };
+  }, [editorView, previewEl, clearScrollSource]);
+}

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -4,14 +4,15 @@ import { renderMarkdown } from "../markdown";
 describe("renderMarkdown", () => {
   it("기본 마크다운을 HTML로 변환한다", async () => {
     const html = await renderMarkdown("# Hello World");
-    expect(html).toContain("<h1>Hello World</h1>");
+    expect(html).toContain("Hello World</h1>");
+    expect(html).toContain("data-source-line=");
   });
 
   it("GFM 테이블을 렌더링한다", async () => {
     const md = `| A | B |\n|---|---|\n| 1 | 2 |`;
     const html = await renderMarkdown(md);
-    expect(html).toContain("<table>");
-    expect(html).toContain("<td>1</td>");
+    expect(html).toContain("<table");
+    expect(html).toContain(">1</td>");
   });
 
   it("GFM 체크박스를 렌더링한다", async () => {
@@ -23,7 +24,7 @@ describe("renderMarkdown", () => {
   it("GFM 취소선을 렌더링한다", async () => {
     const md = `~~deleted~~`;
     const html = await renderMarkdown(md);
-    expect(html).toContain("<del>deleted</del>");
+    expect(html).toContain(">deleted</del>");
   });
 
   it("인라인 수식을 렌더링한다", async () => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -5,6 +5,20 @@ import remarkMath from "remark-math";
 import remarkRehype from "remark-rehype";
 import rehypeKatex from "rehype-katex";
 import rehypeStringify from "rehype-stringify";
+import type { Root, Element } from "hast";
+import { visit } from "unist-util-visit";
+
+function rehypeSourceLine() {
+  return (tree: Root) => {
+    visit(tree, "element", (node: Element) => {
+      const line = node.position?.start?.line;
+      if (line != null) {
+        node.properties ??= {};
+        node.properties["dataSourceLine"] = line;
+      }
+    });
+  };
+}
 
 const processor = unified()
   .use(remarkParse)
@@ -12,6 +26,7 @@ const processor = unified()
   .use(remarkMath)
   .use(remarkRehype)
   .use(rehypeKatex)
+  .use(rehypeSourceLine)
   .use(rehypeStringify);
 
 export async function renderMarkdown(source: string): Promise<string> {


### PR DESCRIPTION
## Summary
- rehype 플러그인으로 HTML 요소에 `data-source-line` 속성 삽입 (소스맵)
- `useScrollSync` 훅으로 에디터 ↔ 프리뷰 양방향 스크롤 동기화
- 스크롤 루프 방지 + 문서 경계 정확 처리 + 중간 영역 보간

## Test plan
- [ ] 에디터 스크롤 시 프리뷰가 같은 위치 표시 확인
- [ ] 프리뷰 스크롤 시 에디터가 같은 위치 표시 확인
- [ ] 긴 문서(헤딩 다수)에서 동기화 정확도 확인
- [ ] 문서 맨 위/맨 아래에서 정확히 동기화되는지 확인
- [ ] 빠른 스크롤 시 떨림/루프 없는지 확인
- [ ] KaTeX, Mermaid 블록 포함 문서에서 정상 동작 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)